### PR TITLE
Use a tenant network at Cambridge

### DIFF
--- a/ansible/group_vars/euclid_cam/infra
+++ b/ansible/group_vars/euclid_cam/infra
@@ -3,8 +3,8 @@ infra_name: "cam"
 
 # Site-specific network configuration.
 infra_net:
-  - net: "cumulus-internal"
-    subnet: "cumulus-internal"
+  - net: "euclid"
+    subnet: "euclid"
     floating_net: "internet"
     security_groups:
       - "default"


### PR DESCRIPTION
We cannot relax port security rules on the cumulus-internal shared network, which prevents us from deploying a gateway.