### PR TITLE
Fix for issue with mount failure on boot

### DIFF
--- a/ansible/setup-cam.yml
+++ b/ansible/setup-cam.yml
@@ -15,7 +15,7 @@
       mount:
         src: "{{ compute_ephemeral_dev }}"
         path: "/mnt"
-        state: unmounted
+        state: absent
       when: mnt_mounted
 
 - hosts:


### PR DESCRIPTION
Error message was:
mount: unknown filesystem type 'LVM2_member'