### PR TITLE
Security groups for RAL compute nodes

### DIFF
--- a/ansible/group_vars/cluster_ral/infra
+++ b/ansible/group_vars/cluster_ral/infra
@@ -12,7 +12,7 @@ infra_net:
       - "intranet"
       - "allow-openvpn"
       - "allow-cam"
-      - "allow-sausage"
+      - "allow-imp"
       - "allow-edi"
 
 # Custom availability zone appears to be necessary for RAL deployments using volumes


### PR DESCRIPTION
Add security group for Imperial College intranet.
Remove rule for Sausage Cloud (StackHPC dev cloud)